### PR TITLE
show dialog if add topics link is clicked when max number of sections is reached

### DIFF
--- a/_course_changenumsections.php
+++ b/_course_changenumsections.php
@@ -103,10 +103,9 @@ if (false) {                                                                    
         update_course((object)array('id' => $course->id,
             'numsections' => $courseformatoptions['numsections']));
     }
-    if (!$returnurl) {
-        $returnurl = course_get_url($course);
-        $returnurl->set_anchor('changenumsections');
-    }
+    // Overwriting returnurl to be consistent with block below even though we never get here.
+    $returnurl = course_get_url($course);
+    $returnurl->set_anchor('changenumsections');
 
 } else if (course_get_format($course)->uses_sections() && $insertsection !== null) {
     if (true) {
@@ -119,10 +118,8 @@ if (false) {                                                                    
         $sections[] = format_multitopic_course_create_section($course, $insertsection);
         // CHANGED LINE ABOVE: Use custom method, and send section info, not section number.
     }
-    if (!$returnurl) {
-        $returnurl = course_get_url($course, $sections[0], []);
-        // CHANGED LINE ABOVE: Send section info, not section number or section return.
-    }
+    $returnurl = course_get_url($course, $sections[0], []);
+    // CHANGED LINE ABOVE: Send section info, not section number or section return.
 }
 
 // Redirect to where we were..

--- a/format.js
+++ b/format.js
@@ -346,10 +346,41 @@ M.course.format.fmtChangeName = function(e) {
 };
 
 /**
+ * Show notice dialog when trying to add sections and maximum has been reached.
+ * @param e
+ * @return {boolean}
+ */
+M.course.format.fmtWarnMaxsections = function(e) {
+    var cantaddlink = e.target.matches('.cantadd');
+
+    if (cantaddlink === false && e.target.firstElementChild !== null) {
+        // Maybe we clicked on the parent <a>.
+        cantaddlink = e.target.firstElementChild.matches('.cantadd');
+    }
+    if (cantaddlink) {
+        e.preventDefault();
+        require(['core/modal_factory', 'core/str'], function(modals, Str) {
+        return modals.create({
+            type: modals.types.ALERT,
+            body: Str.get_string('maxsectionslimit', 'core', M.course.format.fmtMaxsections),
+            title: Str.get_string('notice'),
+            removeOnClose: false,
+        })
+            .then(modal => {
+                modal.show();
+                return modal;
+            });
+        });
+    }
+
+    return true;
+};
+
+/**
  * Initialise: Set the initial state of collapsible sections, and watch for user input.
  */
-M.course.format.fmtInit = function() {
-
+M.course.format.fmtCollapseInit = function(Y,max) {
+    M.course.format.fmtMaxsections = max;
     // Set the initial state of collapsible sections.
     M.course.format.fmtCollapseOnHashChange();
 
@@ -369,11 +400,8 @@ M.course.format.fmtInit = function() {
         var tabcontent = document.querySelector(".course-content ul.sections");
         $(tabcontent).on('updated', M.course.format.fmtChangeName);
     });
-};
 
-// Run initialisation when the page is loaded, or now, if the page is already loaded.
-if (document.readyState == "loading") {
-    document.addEventListener("DOMContentLoaded", M.course.format.fmtInit);
-} else {
-    M.course.format.fmtInit();
-}
+    // Capture clicks on add section links.
+    document.querySelector(".course-content")
+        .addEventListener('click', M.course.format.fmtWarnMaxsections);
+};

--- a/format.js
+++ b/format.js
@@ -360,7 +360,7 @@ M.course.format.fmtWarnMaxsections = function(e) {
     if (cantaddlink) {
         e.preventDefault();
         require(['core/notification'], function(notification) {
-            return notification.addNotification({
+             notification.addNotification({
                 message: M.course.format.fmtMaxsections,
                 type: 'warning'
             });

--- a/format.js
+++ b/format.js
@@ -359,17 +359,16 @@ M.course.format.fmtWarnMaxsections = function(e) {
     }
     if (cantaddlink) {
         e.preventDefault();
-        require(['core/modal_factory', 'core/str'], function(modals, Str) {
-        return modals.create({
-            type: modals.types.ALERT,
-            body: Str.get_string('maxsectionslimit', 'core', M.course.format.fmtMaxsections),
-            title: Str.get_string('notice'),
-            removeOnClose: false,
-        })
-            .then(modal => {
-                modal.show();
-                return modal;
+        require(['core/notification'], function(notification) {
+            return notification.addNotification({
+                message: M.course.format.fmtMaxsections,
+                type: 'warning'
             });
+        });
+        window.scroll({
+            top: 0,
+            left: 0,
+            behavior: 'smooth'
         });
     }
 
@@ -379,7 +378,7 @@ M.course.format.fmtWarnMaxsections = function(e) {
 /**
  * Initialise: Set the initial state of collapsible sections, and watch for user input.
  */
-M.course.format.fmtCollapseInit = function(Y,max) {
+M.course.format.fmtInit = function(Y, max) {
     M.course.format.fmtMaxsections = max;
     // Set the initial state of collapsible sections.
     M.course.format.fmtCollapseOnHashChange();
@@ -400,7 +399,6 @@ M.course.format.fmtCollapseInit = function(Y,max) {
         var tabcontent = document.querySelector(".course-content ul.sections");
         $(tabcontent).on('updated', M.course.format.fmtChangeName);
     });
-
     // Capture clicks on add section links.
     document.querySelector(".course-content")
         .addEventListener('click', M.course.format.fmtWarnMaxsections);

--- a/format.php
+++ b/format.php
@@ -52,6 +52,11 @@ if (false) {                                                                    
 // Include course format js module.
 $courseformat = course_get_format($course);
 $maxsections = method_exists($courseformat, "get_max_sections") ? $courseformat->get_max_sections() : 52;
-$maxsections = get_string('maxsectionslimit', 'core', $maxsections);
+if (get_string_manager()->string_exists('maxsectionslimit', 'core')) {
+    $maxsections = get_string('maxsectionslimit', 'core', $maxsections);
+} else {
+    $maxsections = "Cannot create new section as it would exceed the maximum"
+                 . " number of sections allowed for this course ({$maxsections}).";
+}
 $PAGE->requires->js('/course/format/multitopic/format.js');
 $PAGE->requires->js_init_call('M.course.format.fmtInit', ['max' => $maxsections], true);

--- a/format.php
+++ b/format.php
@@ -50,7 +50,8 @@ if (false) {                                                                    
 }
 
 // Include course format js module.
-$format = course_get_format($course);
-$maxsections = $format->get_max_sections();
+$courseformat = course_get_format($course);
+$maxsections = method_exists($courseformat, "get_max_sections") ? $courseformat->get_max_sections() : 52;
+$maxsections = get_string('maxsectionslimit', 'core', $maxsections);
 $PAGE->requires->js('/course/format/multitopic/format.js');
-$PAGE->requires->js_init_call('M.course.format.fmtCollapseInit', ['max' => $maxsections], true);
+$PAGE->requires->js_init_call('M.course.format.fmtInit', ['max' => $maxsections], true);

--- a/format.php
+++ b/format.php
@@ -50,4 +50,7 @@ if (false) {                                                                    
 }
 
 // Include course format js module.
+$format = course_get_format($course);
+$maxsections = $format->get_max_sections();
 $PAGE->requires->js('/course/format/multitopic/format.js');
+$PAGE->requires->js_init_call('M.course.format.fmtCollapseInit', ['max' => $maxsections], true);

--- a/renderer.php
+++ b/renderer.php
@@ -761,8 +761,8 @@ class format_multitopic_renderer extends format_section_renderer_base {
                         'sesskey' => sesskey(),
                         'insertparentid' => $sectionatlevel[$level - 1]->id,
                         'insertlevel' => $level,
+                        'returnurl' => $this->page->url,
                     ];
-                    $params['returnurl'] = !$canaddmore ? $this->page->url : null;
                     $url = new moodle_url('/course/format/multitopic/_course_changenumsections.php', $params);
                     $attrs = !$canaddmore ? ['class' => 'dimmed_text cantadd'] : null;
                     $icon = $this->output->pix_icon('t/switch_plus', $straddsection, 'moodle', $attrs);
@@ -931,8 +931,8 @@ class format_multitopic_renderer extends format_section_renderer_base {
                 'numsections' => 1,
                 'insertlevel' => FORMAT_MULTITOPIC_SECTION_LEVEL_TOPIC,
                 'sesskey' => sesskey(),
+                'returnurl' => $this->page->url,
             ];
-            $params['returnurl'] = $lastsection >= $maxsections ? $this->page->url : null;
             $url = new moodle_url('/course/format/multitopic/_course_changenumsections.php', $params);
             // REMOVED section return.
             $attrs = $lastsection >= $maxsections ? ['class' => 'cantadd'] : null;

--- a/renderer.php
+++ b/renderer.php
@@ -619,6 +619,8 @@ class format_multitopic_renderer extends format_section_renderer_base {
 
         // ADDED.
         $sections = course_get_format($course)->fmt_get_sections();
+        $format = course_get_format($course);
+        $canaddmore = $format->get_max_sections() > $format->get_last_section_number();
 
         // Find display section.
         if (is_object($displaysection) && isset($displaysection->id)) {
@@ -758,7 +760,8 @@ class format_multitopic_renderer extends format_section_renderer_base {
                             'insertparentid' => $sectionatlevel[$level - 1]->id,
                             'insertlevel' => $level,                            // ADDED.
                         ]);
-                    $icon = $this->output->pix_icon('t/switch_plus', $straddsection);
+                    $attrs = !$canaddmore ? ['class' => 'dimmed cantadd'] : null;
+                    $icon = $this->output->pix_icon('t/switch_plus', $straddsection, 'moodle', $attrs);
                     $newtab = new tabobject("tab_id_{$sectionatlevel[$level - 1]->id}_l{($level - 1)}_add",
                         $url,
                         $icon,
@@ -906,11 +909,6 @@ class format_multitopic_renderer extends format_section_renderer_base {
         // REMOVED: numsections .
 
         if (course_get_format($course)->uses_sections()) {
-            if ($lastsection >= $maxsections) {
-                // Don't allow more sections if we already hit the limit.
-                return '';
-                // TODO: Show anyway, to avoid confusion?
-            }
             // Current course format does not have 'numsections' option but it has multiple sections suppport.
             // Display the "Add section" link that will insert a section in the end.
             // Note to course format developers: inserting sections in the other positions should check both
@@ -926,8 +924,11 @@ class format_multitopic_renderer extends format_section_renderer_base {
                 ['courseid' => $course->id, 'insertparentid' => $insertsection->parentid, 'numsections' => 1,
                 'insertlevel' => FORMAT_MULTITOPIC_SECTION_LEVEL_TOPIC, 'sesskey' => sesskey()]);
             // REMOVED section return.
-            $icon = $this->output->pix_icon('t/add', '');
-            $o .= html_writer::link($url, $icon . $straddsections);              // CHANGED: Only add single section.
+            $attrs = $lastsection >= $maxsections ? ['class' => 'cantadd'] : null;
+            $icon = $this->output->pix_icon('t/add', '',    'moodle', $attrs);
+            $attrs = $lastsection >= $maxsections ? ['class' => 'dimmed'] : null;
+            $o .= html_writer::link($url, $icon . $straddsections, $attrs);              // CHANGED: Only add single section.
+
             $o .= html_writer::end_tag('div');
             return $o;
         }

--- a/styles.css
+++ b/styles.css
@@ -24,7 +24,4 @@ body.format-multitopic.path-mod.pagelayout-incourse #page #page-content .activit
     display: none;
 }
 
-body.format-multitopic #region-main .nav-tabs i.cantadd.dimmed {
-    color: #6c757d;
-}
 /* END ADDED */

--- a/styles.css
+++ b/styles.css
@@ -24,4 +24,7 @@ body.format-multitopic.path-mod.pagelayout-incourse #page #page-content .activit
     display: none;
 }
 
+body.format-multitopic #region-main .nav-tabs i.cantadd.dimmed {
+    color: #6c757d;
+}
 /* END ADDED */


### PR DESCRIPTION
To address todo item in Roadmap: "When max sections is reached, add page tabs are still shown, but add topic links aren't (inconsistency)."

Not sure how you wanted to handle this, but here is one option taking into consideration the inline comment in the renderer: // TODO: Show anyway, to avoid confusion?

The Add topic link is always shown in tabs and at the bottom of the page. It is dimmed if max sections is reached. When clicked a dialog opens displaying the standard text "Cannot create new section as it would exceed the maximum number of sections allowed for this course (20)."