### PR TITLE
Fix for latest code checker warnings

### DIFF
--- a/_course_view.php
+++ b/_course_view.php
@@ -166,7 +166,7 @@ if (true) {                                                                     
     $PAGE->set_pagelayout('course');
     $PAGE->add_body_class('limitedwidth');
 
-    if ($section and $section->section > 0) {
+    if ($section && $section->section > 0) {
         // CHANGED LINE ABOVE: section is now an object. Dereference number property.
 
         // Get section details and check it exists.
@@ -217,7 +217,7 @@ if (true) {                                                                     
         $USER->editing = 0;
     }
     if ($PAGE->user_allowed_editing()) {
-        if (($edit == 1) and confirm_sesskey()) {
+        if (($edit == 1) && confirm_sesskey()) {
             $USER->editing = 1;
             // Redirect to site root if Editing is toggled on frontpage.
             if ($course->id == SITEID) {
@@ -228,7 +228,7 @@ if (true) {                                                                     
                 $url = new \moodle_url($PAGE->url, array('notifyeditingon' => 1));
                 redirect($url);
             }
-        } else if (($edit == 0) and confirm_sesskey()) {
+        } else if (($edit == 0) && confirm_sesskey()) {
             $USER->editing = 0;
             if (!empty($USER->activitycopy) && $USER->activitycopycourse == $course->id) {
                 $USER->activitycopy       = false;
@@ -309,7 +309,7 @@ if (true) {                                                                     
     }
 
     // If viewing a section, make the title more specific.
-    if ($section and $section->section > 0 and course_format_uses_sections($course->format)) { // CHANGED: Dereference section num.
+    if ($section && $section->section > 0 && course_format_uses_sections($course->format)) { // CHANGED: Dereference section num.
         $sectionname = get_string('sectionname', "format_$course->format");
         $sectiontitle = get_section_name($course, $section);
         $PAGE->set_title(get_string('coursesectiontitle', 'moodle',


### PR DESCRIPTION
Addresses the code checker warnings `Logical operator "and" is prohibited; use "&&" instead`